### PR TITLE
abort after 5 clipped presentations + capped max level

### DIFF
--- a/siam.m
+++ b/siam.m
@@ -45,7 +45,7 @@ assert(discardreversals>=0 && discardreversals<minreversals);
 assert(minmeasures >= 1);
 
 % Measure loop
-while sum(abs(reversals))<minreversals || sum(presentations(measures==1))<minmeasures || clip_count<clip_count_to_abort_experiment
+while ( sum(abs(reversals))<minreversals || sum(presentations(measures==1))<minmeasures ) && clip_count<clip_count_to_abort_experiment
   count = count + 1;
 
   % omit clipping

--- a/siam.m
+++ b/siam.m
@@ -45,7 +45,7 @@ assert(discardreversals>=0 && discardreversals<minreversals);
 assert(minmeasures >= 1);
 
 % Measure loop
-while sum(abs(reversals))<minreversals || sum(presentations(measures==1))<minmeasures || clip_count>clip_count_to_abort_experiment
+while sum(abs(reversals))<minreversals || sum(presentations(measures==1))<minmeasures || clip_count<clip_count_to_abort_experiment
   count = count + 1;
 
   % omit clipping


### PR DESCRIPTION
Clipping is now considered.
When the level of the signal exceeds the `clip_value` more than `clip_count_to_abort_experiment` amount of times, the experiment is aborted. 
Further, if `value` exceeds `clip_value`, it is set to  `clip_value`.